### PR TITLE
Add fallback dialer support

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -119,6 +120,14 @@ func RunAndReturnWaitGroup(
 		secretProvider, err = secret.NewSecretProvider(serviceConfig, envVars, ctx, startupTimer, dic, serviceKey)
 		if err != nil {
 			fatalError(fmt.Errorf("failed to create SecretProvider: %s", err.Error()), lc)
+		}
+
+		bootstrapConfig := serviceConfig.GetBootstrap()
+		if bootstrapConfig.Registry.Type == "keeper" {
+			// TODO: address this issue in some way? the openziti fallback dialer should be dialing this address if not zitified
+			// Bypass the zero trust zitidfied transport for Core Keeper Registry client
+			// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
+			secretProvider.SetHttpTransport(http.DefaultTransport)
 		}
 	}
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -19,7 +19,6 @@ package bootstrap
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -121,10 +120,6 @@ func RunAndReturnWaitGroup(
 		if err != nil {
 			fatalError(fmt.Errorf("failed to create SecretProvider: %s", err.Error()), lc)
 		}
-
-		// Bypass the zero trust zitidfied transport for Core Keeper Configuration client
-		// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
-		secretProvider.SetHttpTransport(http.DefaultTransport)
 	}
 
 	// The SecretProvider is initialized and placed in the DIS as part of processing the configuration due

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -19,6 +19,7 @@ package bootstrap
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -128,6 +129,7 @@ func RunAndReturnWaitGroup(
 			// Bypass the zero trust zitidfied transport for Core Keeper Registry client
 			// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
 			secretProvider.SetHttpTransport(http.DefaultTransport)
+			secretProvider.SetFallbackDialer(&net.Dialer{})
 		}
 	}
 

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -18,6 +18,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -76,6 +77,7 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 				return false
 			} else {
 				sp.SetHttpTransport(rt) //only need to set the transport when using SecretProviderExt
+				sp.SetFallbackDialer(&net.Dialer{})
 			}
 
 			if !serviceInfo.UseMessageBus {

--- a/bootstrap/interfaces/secret.go
+++ b/bootstrap/interfaces/secret.go
@@ -15,6 +15,7 @@
 package interfaces
 
 import (
+	"net"
 	"net/http"
 	"time"
 )
@@ -77,6 +78,12 @@ type SecretProviderExt interface {
 
 	// SetHttpTransport sets the http.RoundTripper to be used by http-based clients
 	SetHttpTransport(rt http.RoundTripper)
+
+	// FallbackDialer returns the dialer to use to establish connections when there is no zero trust service found/authorized
+	FallbackDialer() *net.Dialer
+
+	// SetFallbackDialer sets the dialer to use to establish connections when there is no zero trust service found/authorized
+	SetFallbackDialer(dialer *net.Dialer)
 
 	// IsZeroTrustEnabled returns whether zero trust principles are enabled
 	IsZeroTrustEnabled() bool

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -68,10 +69,12 @@ func createRegistryClient(
 		if err != nil {
 			return nil, err
 		}
-		// TODO: address this issue in some way? the openziti fallback dialer should be dialing this address if not zitified
-		// Bypass the zero trust zitidfied transport for Core Keeper Registry client
-		// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
-		// secretProvider.SetHttpTransport(http.DefaultTransport)
+		if bootstrapConfig.Registry.Type == "keeper" {
+			// TODO: address this issue in some way? the openziti fallback dialer should be dialing this address if not zitified
+			// Bypass the zero trust zitidfied transport for Core Keeper Registry client
+			// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
+			secretProvider.SetHttpTransport(http.DefaultTransport)
+		}
 	}
 
 	if len(bootstrapConfig.Registry.Host) == 0 || bootstrapConfig.Registry.Port == 0 || len(bootstrapConfig.Registry.Type) == 0 {

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
@@ -69,10 +68,10 @@ func createRegistryClient(
 		if err != nil {
 			return nil, err
 		}
-
+		// TODO: address this issue in some way? the openziti fallback dialer should be dialing this address if not zitified
 		// Bypass the zero trust zitidfied transport for Core Keeper Registry client
 		// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
-		secretProvider.SetHttpTransport(http.DefaultTransport)
+		// secretProvider.SetHttpTransport(http.DefaultTransport)
 	}
 
 	if len(bootstrapConfig.Registry.Host) == 0 || bootstrapConfig.Registry.Port == 0 || len(bootstrapConfig.Registry.Type) == 0 {

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
@@ -74,6 +75,7 @@ func createRegistryClient(
 			// Bypass the zero trust zitidfied transport for Core Keeper Registry client
 			// Should leverage the HttpTransportFromService function from zerotrust pkg, set the default transport for now
 			secretProvider.SetHttpTransport(http.DefaultTransport)
+			secretProvider.SetFallbackDialer(&net.Dialer{})
 		}
 	}
 

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -20,6 +20,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -260,5 +261,13 @@ func (p *InsecureProvider) IsZeroTrustEnabled() bool {
 }
 
 func (p *InsecureProvider) EnableZeroTrust() {
+	//empty on purpose
+}
+
+func (p *InsecureProvider) FallbackDialer() *net.Dialer {
+	return &net.Dialer{}
+}
+
+func (p *InsecureProvider) SetFallbackDialer(_ *net.Dialer) {
 	//empty on purpose
 }

--- a/bootstrap/secret/jwtprovider.go
+++ b/bootstrap/secret/jwtprovider.go
@@ -14,22 +14,14 @@ import (
 )
 
 type jwtSecretProvider struct {
-	secretProvider interfaces.SecretProviderExt
-	roundTripper_a http.RoundTripper
+	secretProvider      interfaces.SecretProviderExt
+	defaultRoundTripper http.RoundTripper
 }
 
 func NewJWTSecretProvider(secretProvider interfaces.SecretProviderExt) clientinterfaces.AuthenticationInjector {
 	return &jwtSecretProvider{
 		secretProvider: secretProvider,
 	}
-}
-func NewJWTSecretProviderWithRT(secretProvider interfaces.SecretProviderExt, roundTripper_b http.RoundTripper) clientinterfaces.AuthenticationInjector {
-	j := &jwtSecretProvider{
-		secretProvider: secretProvider,
-		roundTripper_a: roundTripper_b,
-	}
-	secretProvider.SetHttpTransport(roundTripper_b)
-	return j
 }
 
 func (self *jwtSecretProvider) AddAuthenticationData(req *http.Request) error {

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -69,6 +70,7 @@ type SecureProvider struct {
 	securityRuntimeSecretTokenDuration gometrics.Timer
 	securityGetSecretDuration          gometrics.Timer
 	httpRoundTripper                   http.RoundTripper
+	fallbackDialer                     *net.Dialer
 	zeroTrustEnabled                   bool
 }
 
@@ -495,6 +497,18 @@ func (p *SecureProvider) HttpTransport() http.RoundTripper {
 func (p *SecureProvider) SetHttpTransport(rt http.RoundTripper) {
 	if p.httpRoundTripper == nil {
 		p.httpRoundTripper = rt
+	} else {
+		p.lc.Warnf("refusing to override httpRoundTripper, already set")
+	}
+}
+
+func (p *SecureProvider) FallbackDialer() *net.Dialer {
+	return p.fallbackDialer
+}
+
+func (p *SecureProvider) SetFallbackDialer(dialer *net.Dialer) {
+	if p.fallbackDialer == nil {
+		p.fallbackDialer = dialer
 	} else {
 		p.lc.Warnf("refusing to override httpRoundTripper, already set")
 	}

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -510,7 +510,7 @@ func (p *SecureProvider) SetFallbackDialer(dialer *net.Dialer) {
 	if p.fallbackDialer == nil {
 		p.fallbackDialer = dialer
 	} else {
-		p.lc.Warnf("refusing to override httpRoundTripper, already set")
+		p.lc.Warnf("refusing to override fallbackDialer, already set")
 	}
 }
 

--- a/bootstrap/zerotrust/zerotrust.go
+++ b/bootstrap/zerotrust/zerotrust.go
@@ -49,7 +49,7 @@ func AuthToOpenZiti(ozController, jwt string) (ziti.Context, error) {
 	return ctx, nil
 }
 
-func HttpTransportFromService(secretProvider interfaces.SecretProviderExt, serviceInfo config.ServiceInfo, lc logger.LoggingClient, fallback *net.Dialer) (http.RoundTripper, error) {
+func HttpTransportFromService(secretProvider interfaces.SecretProviderExt, serviceInfo config.ServiceInfo, lc logger.LoggingClient) (http.RoundTripper, error) {
 	roundTripper := http.DefaultTransport
 	if secretProvider.IsZeroTrustEnabled() {
 		lc.Debugf("zero trust client detected for service: %s", serviceInfo.Host)

--- a/bootstrap/zerotrust/zerotrust.go
+++ b/bootstrap/zerotrust/zerotrust.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"time"
 )
 
 const (
@@ -80,11 +79,7 @@ type ZitiDialer struct {
 }
 
 func (z ZitiDialer) Dial(network, address string) (net.Conn, error) {
-	dialer := net.Dialer{
-		Timeout:   5 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}
-	return dialer.Dial(network, address)
+	return z.underlayDialer.Dial(network, address)
 }
 
 func createZitifiedTransport(secretProvider interfaces.SecretProviderExt, ozController string) (http.RoundTripper, error) {


### PR DESCRIPTION
@jackchenjc - see what you think of these changes. I am not able to test them in your environment, but this might give you an idea of the sort of thing that needs to happen. I'll also leave this same comment on the other PR

> When zero trust mode is enabled, OpenZiti ends up getting configured with a "fallback" dialer. When a network connection is required, if there is no OpenZiti service found (either it doesn't exist or the identity isn't authorized) then OpenZiti will use the fallback to make a connection. If you look at the existing code and trace it, you'll see that ends up using the default net dialer. Right now there was no support for a fallback other than this since it was never needed... 

Hopefully this works, and makes sense?